### PR TITLE
Make Github/Linkedin functions user friendly

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,6 +1,6 @@
 import os
 from pynamodb.models import Model
-from pynamodb.attributes import NumberAttribute
+from pynamodb.attributes import (NumberAttribute, UnicodeAttribute)
 
 # condtionally set host meta attribute unless in production.
 environment = os.getenv("PYTHON_ENV") or "development"
@@ -13,8 +13,12 @@ class DiscordUserModel(Model):
     class Meta:
         table_name = "dynamodb-user"
         if environment == "development":
+            print('using local')
             host = "http://localhost:8000"
     id = NumberAttribute(hash_key=True)
+    first_name = UnicodeAttribute(null=True)
+    last_name = UnicodeAttribute(null=True)
+    github = UnicodeAttribute(null=True)
 
 
 DiscordUserModel.create_table(read_capacity_units=1, write_capacity_units=1)

--- a/database.py
+++ b/database.py
@@ -1,6 +1,6 @@
 import os
 from pynamodb.models import Model
-from pynamodb.attributes import (NumberAttribute, UnicodeAttribute)
+from pynamodb.attributes import NumberAttribute, UnicodeAttribute
 
 # condtionally set host meta attribute unless in production.
 environment = os.getenv("PYTHON_ENV") or "development"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import string
 from discord.utils import get
 import requests
 from bs4 import BeautifulSoup
+from database import DiscordUserModel
 
 TOKEN = os.environ.get("BOT_TOKEN")
 
@@ -23,6 +24,32 @@ async def on_ready():
 async def ping(ctx):
     await ctx.send('pong')
 
+# Store user's Github username
+@client.command(breif="Let us know your Github username so we can connect you with your team!", description="Use '.usergit' followed by your Github username")
+async def set_user_github(ctx: commands.Context, username):
+    user = None
+    try:
+        user = DiscordUserModel.get(ctx.author.id)
+    except DiscordUserModel.DoesNotExist:
+        user = DiscordUserModel(ctx.author.id)
+    
+    user.github = username
+    user.save()
+    await ctx.send(f'Github username saved as https://github.com/{username}')
+
+@client.command(breif="Let us know your Github username so we can connect you with your team!", description="Use '.usergit' followed by your Github username")
+async def get_user_github(ctx: commands.Context):
+    try:
+        user = DiscordUserModel.get(ctx.author.id)
+        #user either has or hasnt set value
+        if user.github:
+            await ctx.send(f'Github username is saved as https://github.com/{user.github}')
+        else:
+             await ctx.send('You have not set this information yet')
+    except DiscordUserModel.DoesNotExist:
+        await ctx.send('You have not set any information yet')
+        return
+    
 # Stack Overflow searcher
 @client.command(brief="Search Stack Overflow", description="Use '.stack' followed by comma separated search terms "
                                                            "to search Stack Overflow. (e.g. '.stack python,string,split')")


### PR DESCRIPTION
Rewrite the functions to be more user friendly:
- shorten functions names
- make so you don't have to ping yourself to set/get your info
- maybe turn into one function instead of both get_github and set_github